### PR TITLE
adding ticket tags into the ticket explore

### DIFF
--- a/_zendesk_block.view.lkml
+++ b/_zendesk_block.view.lkml
@@ -1664,3 +1664,36 @@ view: zendesk_common_term_count {
     sql: ${TABLE}.word ;;
   }
 }
+
+view: ticket_tags {
+  view_label: "Ticket"
+  sql_table_name: zendesk.ticket_tag ;;
+
+# ----- Dimensions -----
+  dimension: tag {
+    group_label: "Basic Ticket Information"
+    description: "A label given to a zendesk ticket. Anything made into a jira ticket automatically has \"jira_escalated\". Tickets can have multiple tags."
+    type: string
+    sql: ${TABLE}.tag ;;
+  }
+
+  dimension: ticket_id {
+    type: number
+    sql: ${TABLE}.ticket_id ;;
+    hidden: yes
+  }
+
+  dimension_group: _fivetran_synced {
+    type: time
+    sql: ${TABLE}._fivetran_synced ;;
+    hidden: yes
+  }
+
+# ----- Measures -----
+  measure: tag_list {
+    description: "A comma seperated list of all tags associated with this product."
+    type: list
+    list_field: tag
+    }
+
+}

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -69,4 +69,9 @@ explore: ticket {
     sql_on: ${ticket.id} = ${number_of_reopens.ticket_id} ;;
     relationship: one_to_one
   }
+
+  join: ticket_tags {
+    sql_on: ${ticket.id} = ${ticket_tags.ticket_id} ;;
+    relationship: many_to_many
+  }
 }


### PR DESCRIPTION
Ticket Tags are the best way for us to see which zendesk tickets have been made into Jira tickets. Every zendesk ticket made into a Jira ticket is given the tag **jira_escalated**

Ticket tag is a separate table in BigQuery and it was left out of the Zendesk block. So I'm modeling it and joining it in 😄 

This will give us insight into which zendesk issues are made into Jira tickets.