### PR TITLE
Adding admin dimensions into the Zendesk space

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -1,0 +1,7 @@
+# This project
+project_name: "zendesk"
+
+# The project to import
+local_dependency: {
+  project: "labelinsight"
+}

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -89,4 +89,11 @@ explore: ticket {
     relationship: many_to_many
   }
 
+  join: mysql_label_insight_users_campaign_choices {
+    view_label: "User Campaign Choices"
+    relationship: one_to_one
+    sql_on: ${mysql_label_insight_users22.id} =  ${mysql_label_insight_users_campaign_choices.user_id}
+      AND ${mysql_label_insight_users_campaign_choices._fivetran_deleted} = FALSE;;
+  }
+
 }

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -3,6 +3,7 @@ connection: "bigquery"
 include: "*_zendesk_block.view"
 include: "*_zendesk_variables.view"
 include: "*.dashboard"
+include: "//labelinsight/mysql_label_insight_users_campaign_choices.view"
 
 explore: ticket {
   join: assignee {

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -4,6 +4,10 @@ include: "*_zendesk_block.view"
 include: "*_zendesk_variables.view"
 include: "*.dashboard"
 include: "//labelinsight/mysql_label_insight_users_campaign_choices.view"
+include: "//labelinsight/mysql_label_insight_users2.view"
+include: "//labelinsight/mysql_label_insight_user_profiles.view"
+
+
 
 explore: ticket {
   join: assignee {
@@ -75,4 +79,12 @@ explore: ticket {
     sql_on: ${ticket.id} = ${ticket_tags.ticket_id} ;;
     relationship: many_to_many
   }
+
+  # adding admin data by joining on user email
+
+  join: mysql_label_insight_user_profiles {
+    sql: ${requester.email} = ${mysql_label_insight_user_profiles.email} ;;
+    relationship: many_to_many
+  }
+
 }

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -82,8 +82,10 @@ explore: ticket {
 
   # adding admin data by joining on user email
 
-  join: mysql_label_insight_user_profiles {
-    sql: ${requester.email} = ${mysql_label_insight_user_profiles.email} ;;
+  join: mysql_label_insight_users22 {
+    view_label: "Label Insight: User Profiles"
+    sql: ${requester.email} = ${mysql_label_insight_users22.email}
+          AND ${mysql_label_insight_users22._fivetran_deleted} = FALSE;;
     relationship: many_to_many
   }
 

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -90,7 +90,7 @@ explore: ticket {
           ]
     view_label: "Label Insight: User Profiles"
     sql_on: ${requester.email} = ${mysql_label_insight_users22.email} ;;
-    relationship: many_to_many
+    relationship: many_to_one
   }
 
   join: mysql_label_insight_users_campaign_choices {

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -89,7 +89,8 @@ explore: ticket {
         mysql_label_insight_users22.company
           ]
     view_label: "Label Insight: User Profiles"
-    sql_on: ${requester.email} = ${mysql_label_insight_users22.email} ;;
+    sql_on: ${requester.email} = ${mysql_label_insight_users22.email}
+            AND ${mysql_label_insight_users22._fivetran_deleted} = FALSE;;
     relationship: many_to_one
   }
 

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -5,8 +5,6 @@ include: "*_zendesk_variables.view"
 include: "*.dashboard"
 include: "//labelinsight/*.view"
 
-
-
 explore: ticket {
   join: assignee {
     sql_on: ${ticket.assignee_id} = ${assignee.id} ;;

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -81,21 +81,20 @@ explore: ticket {
   join: mysql_label_insight_users22 {
     fields:
       [mysql_label_insight_users22.full_name,
-        mysql_label_insight_users22.email,
         mysql_label_insight_users22.email_domain,
         mysql_label_insight_users22.invitation_last_sent_date,
         mysql_label_insight_users22.registered_date,
         mysql_label_insight_users22.registration_completed,
         mysql_label_insight_users22.company
           ]
-    view_label: "Label Insight: User Profiles"
+    view_label: "Requester"
     sql_on: ${requester.email} = ${mysql_label_insight_users22.email}
             AND ${mysql_label_insight_users22._fivetran_deleted} = FALSE;;
     relationship: many_to_one
   }
 
   join: mysql_label_insight_users_campaign_choices {
-    view_label: "Label Insight: User Profiles"
+    view_label: "Requester"
     relationship: one_to_one
     sql_on: ${mysql_label_insight_users22.id} =  ${mysql_label_insight_users_campaign_choices.user_id}
       AND ${mysql_label_insight_users_campaign_choices._fivetran_deleted} = FALSE;;

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -3,8 +3,6 @@ connection: "bigquery"
 include: "*_zendesk_block.view"
 include: "*_zendesk_variables.view"
 include: "*.dashboard"
-include: "//labelinsight/mysql_label_insight_users_campaign_choices.view"
-include: "//labelinsight/mysql_label_insight_users2.view"
 include: "//labelinsight/*.view"
 
 

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -83,6 +83,15 @@ explore: ticket {
   # adding admin data by joining on user email
 
   join: mysql_label_insight_users22 {
+    fields:
+      [mysql_label_insight_users22.full_name,
+        mysql_label_insight_users22.email,
+        mysql_label_insight_users22.email_domain,
+        mysql_label_insight_users22.invitation_last_sent_date,
+        mysql_label_insight_users22.registered_date,
+        mysql_label_insight_users22.registration_completed,
+        mysql_label_insight_users22.company
+          ]
     view_label: "Label Insight: User Profiles"
     sql_on: ${requester.email} = ${mysql_label_insight_users22.email} ;;
     relationship: many_to_many

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -90,7 +90,7 @@ explore: ticket {
   }
 
   join: mysql_label_insight_users_campaign_choices {
-    view_label: "User Campaign Choices"
+    view_label: "Label Insight: User Profiles"
     relationship: one_to_one
     sql_on: ${mysql_label_insight_users22.id} =  ${mysql_label_insight_users_campaign_choices.user_id}
       AND ${mysql_label_insight_users_campaign_choices._fivetran_deleted} = FALSE;;

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -5,7 +5,7 @@ include: "*_zendesk_variables.view"
 include: "*.dashboard"
 include: "//labelinsight/mysql_label_insight_users_campaign_choices.view"
 include: "//labelinsight/mysql_label_insight_users2.view"
-include: "//labelinsight/mysql_label_insight_user_profiles.view"
+include: "//labelinsight/*.view"
 
 
 
@@ -84,13 +84,12 @@ explore: ticket {
 
   join: mysql_label_insight_users22 {
     view_label: "Label Insight: User Profiles"
-    sql: ${requester.email} = ${mysql_label_insight_users22.email}
-          AND ${mysql_label_insight_users22._fivetran_deleted} = FALSE;;
+    sql_on: ${requester.email} = ${mysql_label_insight_users22.email} ;;
     relationship: many_to_many
   }
 
   join: mysql_label_insight_users_campaign_choices {
-    view_label: "Label Insight: User Profiles"
+    view_label: "User Campaign Choices"
     relationship: one_to_one
     sql_on: ${mysql_label_insight_users22.id} =  ${mysql_label_insight_users_campaign_choices.user_id}
       AND ${mysql_label_insight_users_campaign_choices._fivetran_deleted} = FALSE;;

--- a/zendesk_block.model.lkml
+++ b/zendesk_block.model.lkml
@@ -89,7 +89,7 @@ explore: ticket {
   }
 
   join: mysql_label_insight_users_campaign_choices {
-    view_label: "User Campaign Choices"
+    view_label: "Label Insight: User Profiles"
     relationship: one_to_one
     sql_on: ${mysql_label_insight_users22.id} =  ${mysql_label_insight_users_campaign_choices.user_id}
       AND ${mysql_label_insight_users_campaign_choices._fivetran_deleted} = FALSE;;


### PR DESCRIPTION
When diving into onboarding zendesk it's useful to easily pivot and filter by user information. Right now, most of the user info lives in the Admin Explore. It would make analysis much easier if this admin data was added to other explores.