### PR TITLE
Adding in day of week and hour of day to status dates dimension

### DIFF
--- a/_zendesk_block.view.lkml
+++ b/_zendesk_block.view.lkml
@@ -1554,6 +1554,8 @@ view: ticket_history_facts {
     group_label: "Status Dates"
     type: time
     timeframes: [
+      day_of_week,
+      hour_of_day,
       raw,
       time,
       date,


### PR DESCRIPTION
Needed to add Day of Week Response and Hour of Day response to Zendesk block. This will allow us to see how we stand on response times over the week. 